### PR TITLE
Changed logic of client-admin dm to work with message db query properly

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -249,7 +249,7 @@ class EventsController < ApplicationController
 
     data[:clientId] = client._id.to_str
     data[:messages] = []
-    messages = get_event_user_messages(event._id, client._id)
+    messages = get_event_user_messages(event._id, client._id.to_str)
     messages.each do |message|
       data[:messages].push({:messageContent => message.message, :messageFrom => message.from, :messageTo => message.to, :timeSent => message.created_at})
     end
@@ -298,7 +298,7 @@ class EventsController < ApplicationController
         clientObject[:preferenceSubmitted] = true
       end
 
-      messages = get_event_user_messages(event._id, client._id)
+      messages = get_event_user_messages(event._id, client._id.to_str)
       messages.each do |message|
         clientObject[:messages].push({:messageContent => message.message, :messageFrom => message.from, :messageTo => message.to, :timeSent => message.created_at})
       end

--- a/app/javascript/components/Admin/AdminClientDecks.js
+++ b/app/javascript/components/Admin/AdminClientDecks.js
@@ -254,10 +254,10 @@ class AdminClientDecks extends Component {
     sendMessage = () => {
       const payload = {
         content: this.state.messageContent,
-        sender: properties.name,
+        sender: "Producer",
         receiver: this.state.clientList[this.state.client].name,
         event_id: window.location.href.split("/")[-1],
-        user_id: this.state.client
+        user_id: [this.state.client]
       }
 
       const baseURL = window.location.href.split("#")[0]
@@ -353,7 +353,6 @@ class AdminClientDecks extends Component {
                       <AdminUserTable heading="Talents" properties={this.props.properties} currentTab="Client Decks" showCheckbox={false} currentClient={this.state.client} currentTalents={this.state.clientDecks} finalizeTalent={this.finalizeTalent}/>
 
                         <div className="col-md-8 offset-md-2">
-
                             {this.state.expandSlides &&
                             <Paper>
                               <TableContainer>
@@ -491,7 +490,7 @@ class AdminClientDecks extends Component {
                                                             >
                                                             
 
-                                                            {message.messageFrom === properties.name &&
+                                                            {message.messageFrom === "Producer" &&
                                                               <Box
                                                               sx={{
                                                                 display: "flex",              // Align the message and timestamp together
@@ -532,7 +531,7 @@ class AdminClientDecks extends Component {
                                                               </Box>
 
                                                             }
-                                                            {message.messageFrom != properties.name &&
+                                                            {message.messageFrom != "Producer" &&
                                                               <Box
                                                               sx={{
                                                                 display: "flex",

--- a/app/javascript/components/Client/ClientEventFeedback.js
+++ b/app/javascript/components/Client/ClientEventFeedback.js
@@ -146,7 +146,7 @@ class ClientEventFeedback extends Component {
         receiver: 'Producer',
         sender: this.props.properties.name,
         event_id: window.location.href.split("/")[-1],
-        user_id: this.state.clientId
+        user_id: [this.state.clientId]
       }
 
       const baseURL = window.location.href.split("#")[0]


### PR DESCRIPTION
Internally, queries to the messages database was expecting the user_ids field to be an array of strings. These changes were made during the work on the user story for talent-admin group dm. The client-admin dms were not changed to reflect these originally, but now the issue is resolved with this fix.